### PR TITLE
Stop using removed theme properties

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,13 +1,13 @@
 {
     "manifest_version": 2,
     "name": "Chromatastic",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "author": "Danny Guo",
     "homepage_url": "https://github.com/dguo/chromatastic",
     "applications": {
         "gecko": {
             "id": "@chromatastic",
-            "strict_min_version": "60.0a1"
+            "strict_min_version": "63.0a1"
         }
     },
     "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chromatastic",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Dynamic Firefox theme",
     "homepage": "https://github.com/dguo/chromatastic",
     "bugs": "https://github.com/dguo/chromatastic/issues",

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 const fontColorContrast = require('font-color-contrast');
 const hsvToRgb = require('hsv-rgb');
 
@@ -14,11 +12,10 @@ const colorGenerator = getColor();
 
 function updateTheme() {
     const color = colorGenerator.next().value;
-    // console.log(color);
     const theme = {
         colors: {
-            accentcolor: color,
-            textcolor: fontColorContrast(color)
+            frame: color,
+            tab_background_text: fontColorContrast(color)
         }
     };
 


### PR DESCRIPTION
"accentcolor" and "textcolor" are removed as of Firefox 70.